### PR TITLE
#38 Add semver support for macOS/Windows and refactor install scripts

### DIFF
--- a/.github/workflows/test-install-scripts.yaml
+++ b/.github/workflows/test-install-scripts.yaml
@@ -1,0 +1,82 @@
+name: Test install scripts
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  test-linux:
+    name: "Linux: ${{ matrix.senzingsdk-version }}"
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        senzingsdk-version: [production-v4, staging-v4, "4.2.1"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run install script
+        env:
+          PACKAGES_TO_INSTALL: senzingsdk-runtime
+          SENZING_ACCEPT_EULA: I_ACCEPT_THE_SENZING_EULA
+          SENZING_INSTALL_VERSION: ${{ matrix.senzingsdk-version }}
+        run: bash linux/install-senzing.sh
+
+  test-macos:
+    name: "macOS: ${{ matrix.senzingsdk-version }}"
+    permissions:
+      contents: read
+    runs-on: macos-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        senzingsdk-version: [production-v4, staging-v4, "4.2.1"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run install script
+        env:
+          SENZING_INSTALL_VERSION: ${{ matrix.senzingsdk-version }}
+        run: bash darwin/install-senzing.sh
+
+  test-windows:
+    name: "Windows: ${{ matrix.senzingsdk-version }}"
+    permissions:
+      contents: read
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        senzingsdk-version: [production-v4, staging-v4, "4.2.1"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run install script
+        env:
+          SENZING_INSTALL_VERSION: ${{ matrix.senzingsdk-version }}
+        shell: bash
+        run: bash windows/install-senzing.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning].
 
 -
 
+## [4.0.0] - 2026-03-12
+
+### Changed in 4.0.0
+
+- `senzingsdk-version` is now a required input
+- `senzingsdk-repository-path` now requires `senzingsdk-version` to be set (previously defaulted to major version 4)
+- Refactored install scripts to separate repository selection, version extraction, and artifact resolution into distinct phases
+
+### Added in 4.0.0
+
+- Semantic version support (`X.Y.Z`) for macOS and Windows — resolves the latest build for the given version from the S3 bucket
+- Error handling when no matching artifact is found in the S3 bucket
+
 ## [1.0.0] - 2024-11-12
 
 ### Added to 1.0.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GitHub Action for installing the Senzing SDK **V4 or higher**.
 
 ## Overview
 
-The GitHub Action performs a [system install] of the Senzing ADK.
+The GitHub Action performs a [system install] of the Senzing SDK.
 The GitHub Action works where the [RUNNER_OS]
 GitHub variable is `Linux`, `macOS`, or `Windows`.
 
@@ -25,13 +25,13 @@ GitHub variable is `Linux`, `macOS`, or `Windows`.
        runs-on: ubuntu-latest
        steps:
          - name: Install Senzing SDK
-           uses: senzing-factory/github-action-install-senzing-sdk@v1
+           uses: senzing-factory/github-action-install-senzing-sdk@v4
            with:
              senzingsdk-version: production-v4
    ```
 
 1. An example `.github/workflows/install-senzing-example.yaml` file
-   which installs a specific Senzing SDK version:
+   which installs the latest build of a specific semantic version:
 
    ```yaml
    name: install senzing example
@@ -43,7 +43,25 @@ GitHub variable is `Linux`, `macOS`, or `Windows`.
        runs-on: ubuntu-latest
        steps:
          - name: Install Senzing SDK
-           uses: senzing-factory/github-action-install-senzing-sdk@v1
+           uses: senzing-factory/github-action-install-senzing-sdk@v4
+           with:
+             senzingsdk-version: 4.2.2
+   ```
+
+1. An example `.github/workflows/install-senzing-example.yaml` file
+   which installs a specific Senzing SDK build (Linux only):
+
+   ```yaml
+   name: install senzing example
+
+   on: [push]
+
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+       steps:
+         - name: Install Senzing SDK
+           uses: senzing-factory/github-action-install-senzing-sdk@v4
            with:
              senzingsdk-version: 4.0.0-12345
    ```
@@ -62,23 +80,35 @@ GitHub variable is `Linux`, `macOS`, or `Windows`.
        runs-on: ubuntu-latest
        steps:
          - name: Install Senzing SDK
-           uses: senzing-factory/github-action-install-senzing-sdk@v1
+           uses: senzing-factory/github-action-install-senzing-sdk@v4
            with:
              packages-to-install: "senzingsdk-runtime senzingsdk-setup"
              senzingsdk-version: 4.0.0
    ```
 
-### package(s)-to-install
+1. An example `.github/workflows/install-senzing-example.yaml` file
+   which installs from a specific semantic version from production
+   instead of the default staging:
 
-`package(s)-to-install` values can include the following:
+   ```yaml
+   name: install senzing example
 
-- Version >= 4.0:
-  - `senzingsdk-poc`
-  - `senzingsdk-runtime`
-  - `senzingsdk-setup`
-  - `senzingsdk-tools`
+   on: [push]
 
-### senzingsdk-version
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+       steps:
+         - name: Install Senzing SDK
+           uses: senzing-factory/github-action-install-senzing-sdk@v4
+           with:
+             senzingsdk-version: 4.2.2
+             senzingsdk-repository: production
+   ```
+
+### Inputs
+
+#### senzingsdk-version (required)
 
 `senzingsdk-version` values can include the following:
 
@@ -89,11 +119,38 @@ GitHub variable is `Linux`, `macOS`, or `Windows`.
   - Ex. `staging-v4`
   - This will install the latest version of the respective major version from _staging_.
 - `X.Y.Z`
-  - Ex. `4.0.0`
-  - This will install the latest build of the respective semantic version from _production_.
-- `X.Y.Z-ABCDE`
+  - Ex. `4.2.2`
+  - This will install the latest build of the respective semantic version.
+  - Defaults to _staging_. Use `senzingsdk-repository` to override.
+- `X.Y.Z-ABCDE` (Linux only)
   - Ex. `4.0.0-12345`
-  - This will install the exact version supplied from _production_.
+  - This will install the exact version supplied.
+  - Defaults to _staging_. Use `senzingsdk-repository` to override.
+- `X.Y.Z.ABCDE` (macOS and Windows only)
+  - Ex. `4.0.0.12345`
+  - This will install the exact version supplied.
+  - Defaults to _staging_. Use `senzingsdk-repository` to override.
+
+#### packages-to-install (Linux only)
+
+`packages-to-install` values can include the following:
+
+- `senzingsdk-poc`
+- `senzingsdk-runtime` (default)
+- `senzingsdk-setup`
+- `senzingsdk-tools`
+
+#### senzingsdk-repository
+
+Override the repository for semantic version installs. Values: `staging` (default) or `production`.
+
+#### senzingsdk-repository-path
+
+Optional S3 repository override for senzing packages outside of staging and production. Requires `senzingsdk-version`.
+
+#### senzingsdk-repository-package (Linux only)
+
+Optional repository package override for senzing packages outside of staging and production.
 
 [RUNNER_OS]: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
 [system install]: https://github.com/senzing-garage/knowledge-base/blob/main/WHATIS/senzing-system-installation.md

--- a/action.yaml
+++ b/action.yaml
@@ -11,16 +11,17 @@ inputs:
   senzingsdk-repository-package:
     description: Optional repository package override for senzing packages outside of staging and production. Linux only.
   senzingsdk-repository-path:
-    description: Optional repository override for senzing packages outside of staging and production.
+    description: Optional repository override for senzing packages outside of staging and production. Requires senzingsdk-version.
   senzingsdk-version:
     description: Version of Senzing SDK to install
+    required: true
 
 runs:
   using: composite
   steps:
     - if: runner.os == 'Linux'
       name: Run on Linux
-      uses: senzing-factory/github-action-install-senzing-sdk/linux@v3
+      uses: senzing-factory/github-action-install-senzing-sdk/linux@v4
       with:
         packages-to-install: ${{ inputs.packages-to-install }}
         senzingsdk-repository: ${{ inputs.senzingsdk-repository }}
@@ -30,7 +31,7 @@ runs:
 
     - if: runner.os == 'macOS'
       name: Run on macOS
-      uses: senzing-factory/github-action-install-senzing-sdk/darwin@v3
+      uses: senzing-factory/github-action-install-senzing-sdk/darwin@v4
       with:
         senzingsdk-repository: ${{ inputs.senzingsdk-repository }}
         senzingsdk-repository-path: ${{ inputs.senzingsdk-repository-path }}
@@ -38,7 +39,7 @@ runs:
 
     - if: runner.os == 'Windows'
       name: Run on Windows
-      uses: senzing-factory/github-action-install-senzing-sdk/windows@v3
+      uses: senzing-factory/github-action-install-senzing-sdk/windows@v4
       with:
         senzingsdk-repository: ${{ inputs.senzingsdk-repository }}
         senzingsdk-repository-path: ${{ inputs.senzingsdk-repository-path }}

--- a/darwin/install-senzing.sh
+++ b/darwin/install-senzing.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
+
+# Clean up temp files on exit
+trap 'rm -f /tmp/staging-versions /tmp/senzingsdk.dmg' EXIT
 
 ############################################
 # configure-vars
 # GLOBALS:
 #   SENZING_INSTALL_VERSION
 #     one of: production-v<X>, staging-v<X>
+#             X.Y.Z, X.Y.Z.ABCDE
 ############################################
 configure-vars() {
 
@@ -14,68 +18,60 @@ configure-vars() {
   STAGING_URI="s3://senzing-staging-osx/"
   STAGING_URL="https://senzing-staging-osx.s3.amazonaws.com/"
 
-  if [[ "$SENZING_INSTALL_VERSION" =~ "production" ]]; then
-
-    echo "[INFO] install senzingsdk from production"
-    get-generic-major-version
-    is-major-version-greater-than-3
-    SENZINGSDK_URI="$PRODUCTION_URI"
-    SENZINGSDK_URL="$PRODUCTION_URL"
-    determine-latest-dmg-for-major-version
-
-  elif [ -z "$SENZING_INSTALL_VERSION" ] && [ -n "$SENZINGSDK_REPOSITORY_PATH" ]; then
+  # Phase 1: Determine repository
+  if [ -n "$SENZINGSDK_REPOSITORY_PATH" ]; then
 
     echo "[INFO] install senzingsdk from supplied repository"
-    MAJOR_VERSION=4
-    export MAJOR_VERSION
     SENZINGSDK_URI="s3://$SENZINGSDK_REPOSITORY_PATH/"
     SENZINGSDK_URL="https://$SENZINGSDK_REPOSITORY_PATH.s3.amazonaws.com/"
-    determine-latest-dmg-for-major-version
 
-  elif [[ "$SENZING_INSTALL_VERSION" =~ "staging" ]]; then
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^production-v[0-9]+$ ]]; then
+
+    echo "[INFO] install senzingsdk from production"
+    SENZINGSDK_URI="$PRODUCTION_URI"
+    SENZINGSDK_URL="$PRODUCTION_URL"
+
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^staging-v[0-9]+$ ]]; then
 
     echo "[INFO] install senzingsdk from staging"
-    get-generic-major-version
-    is-major-version-greater-than-3
     SENZINGSDK_URI="$STAGING_URI"
     SENZINGSDK_URL="$STAGING_URL"
-    determine-latest-dmg-for-major-version
 
-  elif [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]{5}$ ]]; then
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
 
     REPO="${SENZINGSDK_REPOSITORY:-staging}"
     echo "[INFO] install senzingsdk version $SENZING_INSTALL_VERSION from $REPO"
     if [[ "$REPO" == "production" ]]; then
       SENZINGSDK_URI="$PRODUCTION_URI"
       SENZINGSDK_URL="$PRODUCTION_URL"
-    elif [[ "$REPO" == "staging" ]]; then
+    else
       SENZINGSDK_URI="$STAGING_URI"
       SENZINGSDK_URL="$STAGING_URL"
     fi
-    MAJOR_VERSION="${SENZING_INSTALL_VERSION:0:1}"
-    export MAJOR_VERSION
-    is-major-version-greater-than-3
-    determine-dmg-for-version
 
   else
     echo "[ERROR] senzingsdk install version $SENZING_INSTALL_VERSION is unsupported"
     exit 1
-  fi 
+  fi
 
-}
-
-############################################
-# get-generic-major-version
-# GLOBALS:
-#   SENZING_INSTALL_VERSION
-#     one of: production-v<X>, staging-v<X>
-#     semver does not apply here
-############################################
-get-generic-major-version(){
-
-  MAJOR_VERSION=$(echo "$SENZING_INSTALL_VERSION" | grep -Eo '[0-9]+$')
-  echo "[INFO] major version is: $MAJOR_VERSION"
+  # Phase 2: Determine major version
+  if [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    MAJOR_VERSION="${SENZING_INSTALL_VERSION%%.*}"
+  else
+    MAJOR_VERSION=$(echo "$SENZING_INSTALL_VERSION" | grep -Eo '[0-9]+$')
+  fi
   export MAJOR_VERSION
+  echo "[INFO] major version is: $MAJOR_VERSION"
+  is-major-version-greater-than-3
+
+  # Phase 3: Determine artifact to download
+  if [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]{5}$ ]]; then
+    determine-dmg-for-version
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    determine-latest-dmg-for-semver
+  else
+    determine-latest-dmg-for-major-version
+  fi
 
 }
 
@@ -83,8 +79,6 @@ get-generic-major-version(){
 # is-major-version-greater-than-3
 # GLOBALS:
 #   MAJOR_VERSION
-#     set prior to this call via
-#     get-generic-major-version
 ############################################
 is-major-version-greater-than-3() {
 
@@ -102,18 +96,44 @@ is-major-version-greater-than-3() {
 ############################################
 # determine-latest-dmg-for-major-version
 # GLOBALS:
-#   SENZING_INSTALL_VERSION
-#     one of: production-v<X>, staging-v<X>
+#   MAJOR_VERSION
 #   SENZINGSDK_URI
+#   SENZINGSDK_URL
 ############################################
 determine-latest-dmg-for-major-version() {
 
-  aws s3 ls "$SENZINGSDK_URI" --recursive --no-sign-request | grep -o -E '[^ ]+.dmg$' > /tmp/staging-versions
-  latest_staging_version=$(< /tmp/staging-versions grep "_$MAJOR_VERSION" | sort -r | head -n 1)
-  rm /tmp/staging-versions
-  echo "[INFO] latest staging version is: $latest_staging_version"
+  aws s3 ls "$SENZINGSDK_URI" --recursive --no-sign-request | grep -o -E '[^ ]+\.dmg$' > /tmp/staging-versions
+  latest_staging_version=$(grep "_${MAJOR_VERSION}" /tmp/staging-versions | sort -r | head -n 1) || true
+  rm -f /tmp/staging-versions
+  if [ -z "$latest_staging_version" ]; then
+    echo "[ERROR] no DMG found for major version $MAJOR_VERSION"
+    exit 1
+  fi
+  echo "[INFO] latest version for major version $MAJOR_VERSION is: $latest_staging_version"
 
   SENZINGSDK_DMG_URL="$SENZINGSDK_URL$latest_staging_version"
+
+}
+
+############################################
+# determine-latest-dmg-for-semver
+# GLOBALS:
+#   SENZING_INSTALL_VERSION
+#   SENZINGSDK_URI
+#   SENZINGSDK_URL
+############################################
+determine-latest-dmg-for-semver() {
+
+  aws s3 ls "$SENZINGSDK_URI" --recursive --no-sign-request | grep -o -E '[^ ]+\.dmg$' > /tmp/staging-versions
+  latest_semver_version=$(grep "_${SENZING_INSTALL_VERSION}\." /tmp/staging-versions | sort -r | head -n 1) || true
+  rm -f /tmp/staging-versions
+  if [ -z "$latest_semver_version" ]; then
+    echo "[ERROR] no DMG found for version $SENZING_INSTALL_VERSION"
+    exit 1
+  fi
+  echo "[INFO] latest build for $SENZING_INSTALL_VERSION is: $latest_semver_version"
+
+  SENZINGSDK_DMG_URL="$SENZINGSDK_URL$latest_semver_version"
 
 }
 
@@ -121,8 +141,7 @@ determine-latest-dmg-for-major-version() {
 # determine-dmg-for-version
 # GLOBALS:
 #   SENZING_INSTALL_VERSION
-#     one of: production-v<X>, staging-v<X>
-#   SENZINGSDK_URI
+#   SENZINGSDK_URL
 ############################################
 determine-dmg-for-version() {
 
@@ -137,18 +156,13 @@ determine-dmg-for-version() {
 ############################################
 download-dmg() {
 
-  echo "[INFO] curl --output /tmp/senzingsdk.dmg SENZINGSDK_DMG_URL_REDACTED"
-  curl --output /tmp/senzingsdk.dmg "$SENZINGSDK_DMG_URL"
+  echo "[INFO] curl --fail --output /tmp/senzingsdk.dmg SENZINGSDK_DMG_URL_REDACTED"
+  curl --fail --output /tmp/senzingsdk.dmg "$SENZINGSDK_DMG_URL"
 
 }
 
 ############################################
 # install-senzing
-# GLOBALS:
-#   MAJOR_VERSION
-#     set prior to this call via either
-#     get-generic-major-version or
-#     get-semantic-major-version
 ############################################
 install-senzing() {
 
@@ -156,16 +170,12 @@ install-senzing() {
   hdiutil attach /tmp/senzingsdk.dmg
   sudo mkdir -p "$HOME"/senzing
   sudo cp -R /Volumes/SenzingSDK/senzing/* "$HOME"/senzing/
+  hdiutil detach /Volumes/SenzingSDK
 
 }
 
 ############################################
 # verify-installation
-# GLOBALS:
-#   MAJOR_VERSION
-#     set prior to this call via either
-#     get-generic-major-version or
-#     get-semantic-major-version
 ############################################
 verify-installation() {
 

--- a/linux/action.yaml
+++ b/linux/action.yaml
@@ -11,9 +11,10 @@ inputs:
   senzingsdk-repository-package:
     description: Optional repository package override for senzing packages outside of staging and production. Linux only.
   senzingsdk-repository-path:
-    description: Optional repository override for senzing packages outside of staging and production.
+    description: Optional repository override for senzing packages outside of staging and production. Requires senzingsdk-version.
   senzingsdk-version:
     description: Version of Senzing SDK to install
+    required: true
 
 runs:
   using: composite

--- a/linux/install-senzing.sh
+++ b/linux/install-senzing.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 
 ############################################
 # configure-vars
@@ -22,109 +22,81 @@ configure-vars() {
   # semantic version with build number
   REGEX_SEM_VER_BUILD_NUM="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([0-9]){5}$"
 
-  if [ -z "$SENZING_INSTALL_VERSION" ] && [ -n "$SENZINGSDK_REPOSITORY_PATH" ] && [ -n "$SENZINGSDK_REPOSITORY_PACKAGE" ]; then
+  # Phase 1: Determine repository
+  if [ -n "$SENZINGSDK_REPOSITORY_PATH" ] && [ -n "$SENZINGSDK_REPOSITORY_PACKAGE" ]; then
 
     echo "[INFO] install $PACKAGES_TO_INSTALL from supplied repository"
-    MAJOR_VERSION=4
-    export MAJOR_VERSION
     INSTALL_REPO="$SENZINGSDK_REPOSITORY_PATH/$SENZINGSDK_REPOSITORY_PACKAGE"
-    SENZING_PACKAGES="$PACKAGES_TO_INSTALL"
 
-  elif [[ $SENZING_INSTALL_VERSION =~ "production" ]]; then
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^production-v[0-9]+$ ]]; then
 
     echo "[INFO] install $PACKAGES_TO_INSTALL from production"
-    get-generic-major-version
-    is-major-version-greater-than-3
     INSTALL_REPO="$PROD_REPO_V4_AND_ABOVE"
-    SENZING_PACKAGES="$PACKAGES_TO_INSTALL"
 
-  elif [[ $SENZING_INSTALL_VERSION =~ "staging" ]]; then
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^staging-v[0-9]+$ ]]; then
 
     echo "[INFO] install $PACKAGES_TO_INSTALL from staging"
-    get-generic-major-version
-    is-major-version-greater-than-3
     INSTALL_REPO="$STAGING_REPO_V4_AND_ABOVE"
-    SENZING_PACKAGES="$PACKAGES_TO_INSTALL"
 
-  elif [[ $SENZING_INSTALL_VERSION =~ $REGEX_SEM_VER ]]; then
-  
-    get-semantic-major-version
-    is-major-version-greater-than-3
+  elif [[ $SENZING_INSTALL_VERSION =~ $REGEX_SEM_VER ]] || [[ $SENZING_INSTALL_VERSION =~ $REGEX_SEM_VER_BUILD_NUM ]]; then
+
     REPO="${SENZINGSDK_REPOSITORY:-staging}"
     echo "[INFO] install $PACKAGES_TO_INSTALL version $SENZING_INSTALL_VERSION from $REPO"
     if [[ "$REPO" == "production" ]]; then
       INSTALL_REPO="$PROD_REPO_V4_AND_ABOVE"
-    elif [[ "$REPO" == "staging" ]]; then
+    else
       INSTALL_REPO="$STAGING_REPO_V4_AND_ABOVE"
     fi
-    IFS=" " read -r -a packages <<< "$PACKAGES_TO_INSTALL"
-    for package in "${packages[@]}"
-    do
-      if [[ ! $package == *"senzingdata-v"* ]]; then
-        updated_packages+="$package=$SENZING_INSTALL_VERSION* "
-      else
-        updated_packages+="$package "
-      fi
-    done
-    SENZING_PACKAGES="$updated_packages"
-
-  elif [[ $SENZING_INSTALL_VERSION =~ $REGEX_SEM_VER_BUILD_NUM ]]; then
-
-    get-semantic-major-version
-    is-major-version-greater-than-3
-    REPO="${SENZINGSDK_REPOSITORY:-staging}"
-    echo "[INFO] install $PACKAGES_TO_INSTALL version $SENZING_INSTALL_VERSION from $REPO"
-    if [[ "$REPO" == "production" ]]; then
-      INSTALL_REPO="$PROD_REPO_V4_AND_ABOVE"
-    elif [[ "$REPO" == "staging" ]]; then
-      INSTALL_REPO="$STAGING_REPO_V4_AND_ABOVE"
-    fi
-    IFS=" " read -r -a packages <<< "$PACKAGES_TO_INSTALL"
-    for package in "${packages[@]}"
-    do
-      if [[ ! $package == *"senzingdata-v"* ]]; then
-        updated_packages+="$package=$SENZING_INSTALL_VERSION "
-      else
-        updated_packages+="$package "
-      fi
-    done
-    SENZING_PACKAGES="$updated_packages"
 
   else
     echo "[ERROR] $PACKAGES_TO_INSTALL install version $SENZING_INSTALL_VERSION is unsupported"
     exit 1
   fi
 
+  # Phase 2: Determine major version
+  if [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    MAJOR_VERSION="${SENZING_INSTALL_VERSION%%.*}"
+  else
+    MAJOR_VERSION=$(echo "$SENZING_INSTALL_VERSION" | grep -Eo '[0-9]+$')
+  fi
+  export MAJOR_VERSION
+  echo "[INFO] major version is: $MAJOR_VERSION"
+  is-major-version-greater-than-3
+
+  # Phase 3: Determine packages to install
+  if [[ $SENZING_INSTALL_VERSION =~ $REGEX_SEM_VER ]]; then
+    pin-packages-to-version "$SENZING_INSTALL_VERSION*"
+  elif [[ $SENZING_INSTALL_VERSION =~ $REGEX_SEM_VER_BUILD_NUM ]]; then
+    pin-packages-to-version "$SENZING_INSTALL_VERSION"
+  else
+    SENZING_PACKAGES="$PACKAGES_TO_INSTALL"
+  fi
+
 }
 
 ############################################
-# get-generic-major-version
+# pin-packages-to-version
+# Appends version constraint to each package
+# name, excluding senzingdata-v* packages.
+# ARGS:
+#   $1 - version string to pin to
 # GLOBALS:
-#   SENZING_INSTALL_VERSION
-#     one of: production-v<X>, staging-v<X>
-#     semver does not apply here
+#   PACKAGES_TO_INSTALL
 ############################################
-get-generic-major-version(){
+pin-packages-to-version() {
 
-  MAJOR_VERSION=$(echo "$SENZING_INSTALL_VERSION" | grep -Eo '[0-9]+$')
-  echo "[INFO] major version is: $MAJOR_VERSION"
-  export MAJOR_VERSION
-
-}
-
-############################################
-# get-semantic-major-version
-# GLOBALS:
-#   SENZING_INSTALL_VERSION
-#     one of: X.Y.Z, X.Y.Z-ABCDE
-#     production-v<X> and staging-v<X> 
-#     does not apply here
-############################################
-get-semantic-major-version(){
-
-  MAJOR_VERSION=${SENZING_INSTALL_VERSION%%.*}
-  echo "[INFO] major version is: $MAJOR_VERSION"
-  export MAJOR_VERSION
+  local version_pin="$1"
+  local updated_packages=""
+  IFS=" " read -r -a packages <<< "$PACKAGES_TO_INSTALL"
+  for package in "${packages[@]}"
+  do
+    if [[ ! $package == *"senzingdata-v"* ]]; then
+      updated_packages+="$package=$version_pin "
+    else
+      updated_packages+="$package "
+    fi
+  done
+  SENZING_PACKAGES="$updated_packages"
 
 }
 
@@ -132,9 +104,6 @@ get-semantic-major-version(){
 # is-major-version-greater-than-3
 # GLOBALS:
 #   MAJOR_VERSION
-#     set prior to this call via either
-#     get-generic-major-version or
-#     get-semantic-major-version
 ############################################
 is-major-version-greater-than-3() {
 
@@ -158,13 +127,10 @@ is-major-version-greater-than-3() {
 #
 # GLOBALS:
 #   MAJOR_VERSION
-#     set prior to this call via either
-#     get-generic-major-version or
-#     get-semantic-major-version
 ############################################
 restrict-major-version() {
 
-  senzing_packages=$(apt list | grep senzing | cut -d '/' -f 1 | grep -v "data" | grep -v "staging" | grep -v "repo")
+  senzing_packages=$(apt list | grep senzing | cut -d '/' -f 1 | grep -v "data" | grep -v "staging" | grep -v "repo") || true
   echo "[INFO] senzing packages: $senzing_packages"
 
   for package in $senzing_packages
@@ -195,7 +161,7 @@ install-senzing-repository() {
   echo "[INFO] sudo apt-get -y -qq install /tmp/senzingrepo.deb > /dev/null"
   sudo apt-get -yqq install /tmp/senzingrepo.deb  > /dev/null
   echo "[INFO] sudo apt-get -qq update > /dev/null"
-  sudo apt-get update > /dev/null 
+  sudo apt-get update > /dev/null
   rm /tmp/senzingrepo.deb
 
 }
@@ -207,7 +173,7 @@ install-senzing-repository() {
 #     full package name used for install
 ############################################
 install-senzingsdk() {
-  
+
   restrict-major-version
   echo "[INFO] sudo apt list | grep senzing | grep -v repo"
   sudo apt list | grep senzing | grep -v repo
@@ -219,11 +185,6 @@ install-senzingsdk() {
 
 ############################################
 # verify-installation
-# GLOBALS:
-#   MAJOR_VERSION
-#     set prior to this call via either
-#     get-generic-major-version or
-#     get-semantic-major-version
 ############################################
 verify-installation() {
 

--- a/windows/action.yaml
+++ b/windows/action.yaml
@@ -23,7 +23,7 @@ runs:
         SENZINGSDK_REPOSITORY_PATH: ${{ inputs.senzingsdk-repository-path }}
       name: Install Senzing SDK
       shell: bash
-      run: $GITHUB_ACTION_PATH/install-senzing.sh
+      run: ${{ github.action_path }}/install-senzing.sh
 
 branding:
   icon: download

--- a/windows/install-senzing.sh
+++ b/windows/install-senzing.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
+
+# Clean up temp files on exit
+trap 'rm -f /tmp/staging-versions senzingsdk.zip' EXIT
 
 ############################################
 # configure-vars
 # GLOBALS:
 #   SENZING_INSTALL_VERSION
 #     one of: production-v<X>, staging-v<X>
+#             X.Y.Z, X.Y.Z.ABCDE
 ############################################
 configure-vars() {
 
@@ -14,68 +18,60 @@ configure-vars() {
   STAGING_URI="s3://senzing-staging-win/"
   STAGING_URL="https://senzing-staging-win.s3.amazonaws.com/"
 
-  if [[ $SENZING_INSTALL_VERSION =~ "production" ]]; then
-
-    echo "[INFO] install senzingsdk from production"
-    get-generic-major-version
-    is-major-version-greater-than-3
-    SENZINGSDK_URI="$PRODUCTION_URI"
-    SENZINGSDK_URL="$PRODUCTION_URL"
-    determine-latest-zip-for-major-version
-
-  elif [ -z "$SENZING_INSTALL_VERSION" ] && [ -n "$SENZINGSDK_REPOSITORY_PATH" ]; then
+  # Phase 1: Determine repository
+  if [ -n "$SENZINGSDK_REPOSITORY_PATH" ]; then
 
     echo "[INFO] install senzingsdk from supplied repository"
-    MAJOR_VERSION=4
-    export MAJOR_VERSION
     SENZINGSDK_URI="s3://$SENZINGSDK_REPOSITORY_PATH/"
     SENZINGSDK_URL="https://$SENZINGSDK_REPOSITORY_PATH.s3.amazonaws.com/"
-    determine-latest-zip-for-major-version
 
-  elif [[ $SENZING_INSTALL_VERSION =~ "staging" ]]; then
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^production-v[0-9]+$ ]]; then
+
+    echo "[INFO] install senzingsdk from production"
+    SENZINGSDK_URI="$PRODUCTION_URI"
+    SENZINGSDK_URL="$PRODUCTION_URL"
+
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^staging-v[0-9]+$ ]]; then
 
     echo "[INFO] install senzingsdk from staging"
-    get-generic-major-version
-    is-major-version-greater-than-3
     SENZINGSDK_URI="$STAGING_URI"
     SENZINGSDK_URL="$STAGING_URL"
-    determine-latest-zip-for-major-version
 
-  elif [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]{5}$ ]]; then
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
 
     REPO="${SENZINGSDK_REPOSITORY:-staging}"
     echo "[INFO] install senzingsdk version $SENZING_INSTALL_VERSION from $REPO"
     if [[ "$REPO" == "production" ]]; then
       SENZINGSDK_URI="$PRODUCTION_URI"
       SENZINGSDK_URL="$PRODUCTION_URL"
-    elif [[ "$REPO" == "staging" ]]; then
+    else
       SENZINGSDK_URI="$STAGING_URI"
       SENZINGSDK_URL="$STAGING_URL"
     fi
-    MAJOR_VERSION="${SENZING_INSTALL_VERSION:0:1}"
-    export MAJOR_VERSION
-    is-major-version-greater-than-3
-    determine-zip-for-version
 
   else
     echo "[ERROR] senzingsdk install version $SENZING_INSTALL_VERSION is unsupported"
     exit 1
-  fi 
+  fi
 
-}
-
-############################################
-# get-generic-major-version
-# GLOBALS:
-#   SENZING_INSTALL_VERSION
-#     one of: production-v<X>, staging-v<X>
-#     semver does not apply here
-############################################
-get-generic-major-version(){
-
-  MAJOR_VERSION=$(echo "$SENZING_INSTALL_VERSION" | grep -Eo '[0-9]+$')
-  echo "[INFO] major version is: $MAJOR_VERSION"
+  # Phase 2: Determine major version
+  if [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    MAJOR_VERSION="${SENZING_INSTALL_VERSION%%.*}"
+  else
+    MAJOR_VERSION=$(echo "$SENZING_INSTALL_VERSION" | grep -Eo '[0-9]+$')
+  fi
   export MAJOR_VERSION
+  echo "[INFO] major version is: $MAJOR_VERSION"
+  is-major-version-greater-than-3
+
+  # Phase 3: Determine artifact to download
+  if [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]{5}$ ]]; then
+    determine-zip-for-version
+  elif [[ "$SENZING_INSTALL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    determine-latest-zip-for-semver
+  else
+    determine-latest-zip-for-major-version
+  fi
 
 }
 
@@ -83,8 +79,6 @@ get-generic-major-version(){
 # is-major-version-greater-than-3
 # GLOBALS:
 #   MAJOR_VERSION
-#     set prior to this call via
-#     get-generic-major-version
 ############################################
 is-major-version-greater-than-3() {
 
@@ -102,18 +96,44 @@ is-major-version-greater-than-3() {
 ############################################
 # determine-latest-zip-for-major-version
 # GLOBALS:
-#   SENZING_INSTALL_VERSION
-#     one of: production-v<X>, staging-v<X>
+#   MAJOR_VERSION
 #   SENZINGSDK_URI
+#   SENZINGSDK_URL
 ############################################
 determine-latest-zip-for-major-version() {
 
-  aws s3 ls "$SENZINGSDK_URI" --recursive --no-sign-request --region us-east-1 | grep -o -E '[^ ]+.zip$' > /tmp/staging-versions
-  latest_staging_version=$(< /tmp/staging-versions grep "_$MAJOR_VERSION" | sort -r | head -n 1)
-  rm /tmp/staging-versions
-  echo "[INFO] latest staging version is: $latest_staging_version"
+  aws s3 ls "$SENZINGSDK_URI" --recursive --no-sign-request --region us-east-1 | grep -o -E '[^ ]+\.zip$' > /tmp/staging-versions
+  latest_staging_version=$(grep "_${MAJOR_VERSION}" /tmp/staging-versions | sort -r | head -n 1) || true
+  rm -f /tmp/staging-versions
+  if [ -z "$latest_staging_version" ]; then
+    echo "[ERROR] no ZIP found for major version $MAJOR_VERSION"
+    exit 1
+  fi
+  echo "[INFO] latest version for major version $MAJOR_VERSION is: $latest_staging_version"
 
   SENZINGSDK_ZIP_URL="$SENZINGSDK_URL$latest_staging_version"
+
+}
+
+############################################
+# determine-latest-zip-for-semver
+# GLOBALS:
+#   SENZING_INSTALL_VERSION
+#   SENZINGSDK_URI
+#   SENZINGSDK_URL
+############################################
+determine-latest-zip-for-semver() {
+
+  aws s3 ls "$SENZINGSDK_URI" --recursive --no-sign-request --region us-east-1 | grep -o -E '[^ ]+\.zip$' > /tmp/staging-versions
+  latest_semver_version=$(grep "_${SENZING_INSTALL_VERSION}\." /tmp/staging-versions | sort -r | head -n 1) || true
+  rm -f /tmp/staging-versions
+  if [ -z "$latest_semver_version" ]; then
+    echo "[ERROR] no ZIP found for version $SENZING_INSTALL_VERSION"
+    exit 1
+  fi
+  echo "[INFO] latest build for $SENZING_INSTALL_VERSION is: $latest_semver_version"
+
+  SENZINGSDK_ZIP_URL="$SENZINGSDK_URL$latest_semver_version"
 
 }
 
@@ -121,12 +141,11 @@ determine-latest-zip-for-major-version() {
 # determine-zip-for-version
 # GLOBALS:
 #   SENZING_INSTALL_VERSION
-#     one of: production-v<X>, staging-v<X>
-#   SENZINGSDK_URI
+#   SENZINGSDK_URL
 ############################################
 determine-zip-for-version() {
 
-  SENZINGSDK_ZIP_URL="$SENZINGSDK_URL"SenzingSDK_"$latest_staging_version".zip
+  SENZINGSDK_ZIP_URL="$SENZINGSDK_URL"SenzingSDK_"$SENZING_INSTALL_VERSION".zip
 
 }
 
@@ -137,28 +156,23 @@ determine-zip-for-version() {
 ############################################
 download-zip() {
 
-  echo "[INFO] curl --output senzingsdk.zip SENZINGSDK_ZIP_URL_REDACTED"
-  curl --output senzingsdk.zip "$SENZINGSDK_ZIP_URL"
+  echo "[INFO] curl --fail --output senzingsdk.zip SENZINGSDK_ZIP_URL_REDACTED"
+  curl --fail --output senzingsdk.zip "$SENZINGSDK_ZIP_URL"
 
 }
-
 
 ############################################
 # install-senzingsdk
 ############################################
 install-senzingsdk() {
 
-  7z x -y -o"$HOME" senzingsdk.zip 
+  7z x -y -o"$HOME" senzingsdk.zip
+  rm -f senzingsdk.zip
 
 }
 
 ############################################
 # verify-installation
-# GLOBALS:
-#   MAJOR_VERSION
-#     set prior to this call via either
-#     get-generic-major-version or
-#     get-semantic-major-version
 ############################################
 verify-installation() {
 


### PR DESCRIPTION
Previously macOS and Windows required exact build numbers (X.Y.Z.BBBBB) to install a specific SDK version, while Linux supported plain semver (X.Y.Z). This adds semver support to all platforms by listing the S3 bucket and resolving the latest build for a given version.

Breaking changes:
  - senzingsdk-version is now a required input
  - Custom repository paths (senzingsdk-repository-path) now require senzingsdk-version instead of defaulting to major version 4

Refactored configure-vars across all three platform scripts into three distinct phases (repository selection, version extraction, artifact resolution) to eliminate duplicated if/else blocks.

Hardened shell scripts:
  - set -eo pipefail to catch pipeline failures
  - trap for temp file cleanup on exit
  - curl --fail to catch HTTP errors (macOS/Windows)
  - Anchored regex for production/staging version matching
  - Escaped dots in grep patterns for artifact file matching
  - hdiutil detach after DMG copy (macOS)
  - Cleanup of downloaded zip after extraction (Windows)
  - Fixed action.yaml to use github.action_path consistently (Windows)

Extracted duplicated package pinning loop into pin-packages-to-version helper function (Linux).

Added test-install-scripts.yaml workflow to exercise all three platforms with production-v4, staging-v4, and semver (4.2.1) in parallel.

Updated README with v4 examples, new input documentation, and semver  usage. Updated CHANGELOG for 4.0.0 release.

---

Resolves #38